### PR TITLE
Expose snowball-stemmers typings correctly

### DIFF
--- a/@types/snowball-stemmers/index.d.ts
+++ b/@types/snowball-stemmers/index.d.ts
@@ -1,5 +1,7 @@
-export declare class Stemmer {
-    stem(term: string): string;
-}
+declare module 'snowball-stemmers' {
+    export class Stemmer {
+        stem(term: string): string;
+    }
 
-export declare function newStemmer(locale: string): Stemmer;
+    export function newStemmer(locale: string): Stemmer;
+}

--- a/@types/snowball-stemmers/package.json
+++ b/@types/snowball-stemmers/package.json
@@ -2,10 +2,7 @@
     "name": "@types/snowball-stemmers",
     "version": "1.0.0",
     "description": "",
-    "main": "index.js",
-    "scripts": {
-      "test": "echo \"Error: no test specified\" && exit 1"
-    },
+    "main": "",
     "keywords": [],
     "author": "",
     "license": "ISC"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "short-order",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -54,6 +54,9 @@
       "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.3.tgz",
       "integrity": "sha512-YP9NVli96E+qQLAF2db+VjnAUEeZcFVg4YnMgr8kpDUFwQBnj31rPLOVHmazbKQhaIkJ9cMHsZhpKdzUeL0KTg==",
       "dev": true
+    },
+    "@types/snowball-stemmers": {
+      "version": "file:@types/snowball-stemmers"
     },
     "ansi-align": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "short-order",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "description": "A natural language conversational agent for ordering and organizing items from a catalog.",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
@@ -31,6 +31,7 @@
     "@types/node": "^10.11.4",
     "@types/number-to-words": "^1.2.0",
     "@types/readline-sync": "^1.4.3",
+    "@types/snowball-stemmers": "file:@types/snowball-stemmers",
     "chai": "^4.2.0",
     "copyfiles": "^2.1.0",
     "gts": "^0.8.0",
@@ -38,7 +39,6 @@
     "typescript": "~2.8.0"
   },
   "dependencies": {
-    "@types/snowball-stemmers": "file:@types/snowball-stemmers",
     "dotenv": "^6.0.0",
     "js-yaml": "^3.12.0",
     "murmurhash": "0.0.2",


### PR DESCRIPTION
Needed to wrap the `@types/snowball-stemmer` typings in a module
that aligns them with the official `snowball-stemmers` package name so
that consuming applications that reference them align the types
correctly at runtime with the actual JS module.

NOTE: right now this still requires the consuming application to use
either a `typeRoots` or `path` based solution to point to
the `@types/snowball-stemmers` typings files. Still looking for full
solution to that, though the answer is probably to stop shipping the
types as embedded in this package and instead as an official,
@types standalone package.