### PR TITLE
Make TokenizerFunction async

### DIFF
--- a/samples/test_runner.ts
+++ b/samples/test_runner.ts
@@ -1,13 +1,8 @@
 import * as fs from 'fs';
 import * as minimist from 'minimist';
 import * as path from 'path';
+import { AnyToken, setup, TestSuite, TokenizerFunction } from '../src';
 
-import {
-    AnyToken,
-    setup,
-    TestSuite,
-    TokenizerFunction
-} from '../src';
 
 function go() {
     const args = minimist(process.argv.slice(2));
@@ -35,7 +30,7 @@ function go() {
     );
 
     // Set up tokenizer
-    const tokenizer: TokenizerFunction = (utterance: string): IterableIterator<AnyToken> =>
+    const tokenizer: TokenizerFunction = async (utterance: string): Promise<IterableIterator<AnyToken>> =>
         (world.unified.processOneQuery(utterance) as AnyToken[]).values();
 
     const suite = TestSuite.fromYamlString(fs.readFileSync(testFile, 'utf8'));

--- a/samples/test_runner.ts
+++ b/samples/test_runner.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { AnyToken, setup, TestSuite, TokenizerFunction } from '../src';
 
 
-function go() {
+async function go() {
     const args = minimist(process.argv.slice(2));
 
     const defaultTestFile = './data/restaurant-en/test_suite.yaml';
@@ -34,7 +34,7 @@ function go() {
         (world.unified.processOneQuery(utterance) as AnyToken[]).values();
 
     const suite = TestSuite.fromYamlString(fs.readFileSync(testFile, 'utf8'));
-    suite.run(world, showAll, suiteFilter, tokenizer);
+    await suite.run(world, showAll, suiteFilter, tokenizer);
 }
 
 go();


### PR DESCRIPTION

This makes the `TokenizerFunction` return a
`Promise<IterableIterator<AnyToken>>`  now which enables the impl
to be async if you need it to be.

This includes changes to propagate the `async` up through:

  * `TestCase::run`
  * `TestSuite::run`